### PR TITLE
make #mod and #selected separate components

### DIFF
--- a/component.json
+++ b/component.json
@@ -9,6 +9,8 @@
   "scripts": ["index.js"],
   "dependencies": {
     "component/event": "*",
-    "component/raf": "*"
+    "component/raf": "*",
+    "bmcmahen/modifier": "*",
+    "bmcmahen/text-selection": "*"
   }
 }

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@
 var event = require('event');
 var raf = require('raf');
 var caf = raf.cancel;
+var selected = require('text-selection');
+var mod = require('modifier');
 
 /**
  * Selection
@@ -40,30 +42,3 @@ module.exports = function(el, fn){
     event.unbind(el, 'keyup', callback);
   }
 };
-
-/**
- * Check if there's a selection.
- *
- * @return {Boolean}
- * @api public
- */
-
-function selected(){
-  var range = selection.getRangeAt(0);
-  return range.startOffset < range.endOffset;
-};
-
-/**
- * Check if the keyup event is a modifier.
- *
- * @param {Event} e
- * @return {Boolean}
- * @api public
- */
-
-function mod(e){
-  return e.shiftKey
-    || e.altKey
-    || e.ctrlKey
-    || e.metaKey;
-}


### PR DESCRIPTION
closes #1. `#selected` should also eventually be cross-browser.
